### PR TITLE
fix: update github link to site repo on sidebar

### DIFF
--- a/components/navigation/SideBar.vue
+++ b/components/navigation/SideBar.vue
@@ -142,7 +142,7 @@
         <a
           target="blank_"
           class="hover:bg-gracy-700 self-center"
-          href="https://github.com/BibliothecaForAdventurers/main-site"
+          href="https://github.com/BibliothecaForAdventurers/site"
         ><Github
           class="w-8 h-8"
         /></a>


### PR DESCRIPTION
The current github link on the site bar leads to the `main-site` repo, which should have been renamed to `site`.

A fix is implemented to update the link.